### PR TITLE
Fixes issue when +2 duplicate names exist

### DIFF
--- a/builder/ec2.go
+++ b/builder/ec2.go
@@ -43,7 +43,7 @@ func IncrementID(name string, instanceDict map[string]InstanceInfo) string {
 			testlist[len(testlist)-1] = strconv.Itoa(ival)
 			return IncrementID(strings.Join(testlist, "-"), instanceDict)
 		} else {
-			return name + "-2"
+			return IncrementID(name+"-2", instanceDict)
 		}
 	}
 	return name

--- a/builder/ec2_test.go
+++ b/builder/ec2_test.go
@@ -14,9 +14,10 @@ func TestIncrementID(t *testing.T) {
 
 func TestIncrementID2(t *testing.T) {
 	instances := map[string]InstanceInfo{
-		"test-2": InstanceInfo{InstanceID: "i-123456"},
+		"test":   InstanceInfo{InstanceID: "i-111111"},
+		"test-2": InstanceInfo{InstanceID: "i-111112"},
 	}
-	dup_instance := IncrementID("test-2", instances)
+	dup_instance := IncrementID("test", instances)
 	if dup_instance != "test-3" {
 		t.Errorf("Duplicate instnace id should append unique num, got: %s", dup_instance)
 	}


### PR DESCRIPTION
Discovered this when having 3 instances with the same name.
The ssh config was only showing 2 entries when 3 was expected.
Tests werent originally useful either.