### PR TITLE
[READY] Fix version cmd using go linker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,14 @@ GOGET=$(GOCMD) get
 BINARY_NAME=sshcb
 TEST_DIRS = builder
 
+PKG := github.com/sarcasticadmin/sshcb
+VERSION := $(shell git describe --dirty)
+LDFLAGS := -X $(PKG)/cmd.Version=$(VERSION)
+
 all: build
 
 build:
-	$(GOBUILD) -o $(BINARY_NAME) -v
+	$(GOBUILD) -o $(BINARY_NAME) -v -ldflags="$(LDFLAGS)"
 clean:
 	$(GOCLEAN)
 	rm -f $(BINARY_NAME)

--- a/builder/ec2.go
+++ b/builder/ec2.go
@@ -159,7 +159,7 @@ func GetReservs(tags map[string]string, ec2svc *ec2.EC2) *ec2.DescribeInstancesO
 	}
 	resp, err := ec2svc.DescribeInstances(params)
 	if err != nil {
-		logs.FATAL.Printf("there was an error listing instances in", err.Error())
+		logs.FATAL.Printf("there was an error listing instances in: %s", err.Error())
 		log.Fatal(err.Error())
 	}
 	return resp

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Version identifier populated via the CI/CD process.
+var Version = "HEAD"
+
 var verbose bool
 
 var rootCmd = &cobra.Command{
@@ -51,7 +54,7 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version number of SSHcb",
 	Long:  `All software has versions. This is SSHcb`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v0.0")
+		fmt.Println(Version)
 	},
 }
 


### PR DESCRIPTION
Initially the version command was set to "0.0.0" with the hope that
I would eventually get back to actually correctly configuring it.

Luckily, that time has come and Ive opted to reference a few projects
and articles with how to set the -X linker option. Referenced the
following resources for help:
  https://github.com/databus23/helm-diff/
  https://blog.cloudflare.com/setting-go-variables-at-compile-time/

This will now allow me to correctly reference the version via git
tags as well as any versions that are cut outside the normal release
cycle for testing by appending the git SHA to the version.